### PR TITLE
ENG-2030 add informative logs

### DIFF
--- a/knowledge_graph/querying.py
+++ b/knowledge_graph/querying.py
@@ -390,7 +390,7 @@ def get_attribute_first_value(attribute: str, node: storage.Node) -> str:
     return gamla.try_and_excepts(
         StopIteration,  # type: ignore
         gamla.make_raise(
-            _AttributeMissing(f"Attribute: {attribute} is missing")
+            _AttributeMissing(f"Attribute: {attribute} is missing in node id: {node.node_id}")
         )(),
         gamla.head(
             find_attr_display_text(

--- a/knowledge_graph/querying.py
+++ b/knowledge_graph/querying.py
@@ -13,6 +13,10 @@ from . import (
     triplets_index,
 )
 
+
+class _AttributeMissing(Exception):
+    pass
+
 get_nodes_by_relations: Callable[
     [Iterable[triplet.Element]], Callable[[storage.Node], storage.Nodes]
 ] = gamla.compose_left(
@@ -383,10 +387,16 @@ pointing_to_type_siblings = gamla.compose(
 
 @gamla.curry
 def get_attribute_first_value(attribute: str, node: storage.Node) -> str:
-    return gamla.head(
-        find_attr_display_text(
-            node, find_exactly_bare(attribute, storage.get_graph(node.graph_id))
-        )
+    return gamla.try_and_excepts(
+        StopIteration,  # type: ignore
+        gamla.make_raise(
+            _AttributeMissing(f"Attribute: {attribute} is missing")
+        )(),
+        gamla.head(
+            find_attr_display_text(
+                node, find_exactly_bare(attribute, storage.get_graph(node.graph_id))
+            )
+        ),
     )
 
 


### PR DESCRIPTION
Improve non-informative logs as RuntimeError('coroutine raised StopIteration') that raises when we look for an attribute that does not exist in the relevant node/ KG. More info can be found in the corresponding [Jira ticket](https://hyro-ai.atlassian.net/browse/ENG-2030)