### PR TITLE
Do not raise exception for empty graph

### DIFF
--- a/knowledge_graph/storage.py
+++ b/knowledge_graph/storage.py
@@ -114,7 +114,7 @@ def load_to_kg(
         gamla.second,
         gamla.when(
             gamla.compose_left(triplets_index.triplets, gamla.empty),
-            # TODO(Noah) should be make_raise once we no longer cache empty graphs
+            # TODO(Noah): should be make_raise once we no longer cache empty graphs
             gamla.log_text("_EmptyGraphLoaded"),
         ),
     )

--- a/knowledge_graph/storage.py
+++ b/knowledge_graph/storage.py
@@ -115,7 +115,7 @@ def load_to_kg(
         gamla.when(
             gamla.compose_left(triplets_index.triplets, gamla.empty),
             # TODO(Noah) should be make_raise once we no longer cache empty graphs
-            gamla.log_text(_EmptyGraphLoaded),
+            gamla.log_text("_EmptyGraphLoaded"),
         ),
     )
 

--- a/knowledge_graph/storage.py
+++ b/knowledge_graph/storage.py
@@ -115,7 +115,7 @@ def load_to_kg(
         gamla.when(
             gamla.compose_left(triplets_index.triplets, gamla.empty),
             # TODO(Noah) should be make_raise once we no longer cache empty graphs
-            gamla.log(_EmptyGraphLoaded),
+            gamla.log_text(_EmptyGraphLoaded),
         ),
     )
 

--- a/knowledge_graph/storage.py
+++ b/knowledge_graph/storage.py
@@ -14,8 +14,9 @@ GraphHash = str
 _REGISTERED_GRAPHS: Dict[GraphHash, triplets_index.TripletsWithIndex] = {}
 
 
-class _EmptyGraphLoaded(Exception):
-    pass
+# TODO(Noah): should be make_raise once we no longer cache empty graphs
+# class _EmptyGraphLoaded(Exception):
+#     pass
 
 
 def register_graph(hash: GraphHash, graph: triplets_index.TripletsWithIndex):

--- a/knowledge_graph/storage.py
+++ b/knowledge_graph/storage.py
@@ -114,7 +114,8 @@ def load_to_kg(
         gamla.second,
         gamla.when(
             gamla.compose_left(triplets_index.triplets, gamla.empty),
-            gamla.make_raise(_EmptyGraphLoaded),
+            # TODO(Noah) should be make_raise once we no longer cache empty graphs
+            gamla.log(_EmptyGraphLoaded),
         ),
     )
 


### PR DESCRIPTION
We still cache some empty graphs for triplets synonyms, site search etc. the exception prevents building good KGs altogether so for now it's best to just log that the graph was empty.